### PR TITLE
Use 'GetKey' instead of indexing KeyDictionary directly

### DIFF
--- a/WarriorsSnuggery.Game/UI/Objects/ActorList.cs
+++ b/WarriorsSnuggery.Game/UI/Objects/ActorList.cs
@@ -89,7 +89,7 @@ namespace WarriorsSnuggery.UI.Objects
 			{
 				CurrentActor += MouseInput.WheelState;
 
-				if (KeyInput.IsKeyDown(Settings.KeyDictionary["Activate"]) || !KeyInput.IsKeyDown(Keys.LeftControl) && MouseInput.IsRightClicked)
+				if (KeyInput.IsKeyDown(Settings.GetKey("Activate")) || !KeyInput.IsKeyDown(Keys.LeftControl) && MouseInput.IsRightClicked)
 					changePlayer(actorTypes[CurrentActor]);
 
 				for (int i = 0; i < Math.Max(actorTypes.Count, 10); i++)

--- a/WarriorsSnuggery.Game/UI/Objects/SpellList.cs
+++ b/WarriorsSnuggery.Game/UI/Objects/SpellList.cs
@@ -60,7 +60,7 @@ namespace WarriorsSnuggery.UI.Objects
 			if (!KeyInput.IsKeyDown(Keys.LeftShift))
 			{
 				CurrentSpell += MouseInput.WheelState;
-				if (KeyInput.IsKeyDown(Settings.KeyDictionary["Activate"]) || !KeyInput.IsKeyDown(Keys.LeftControl) && MouseInput.IsRightClicked)
+				if (KeyInput.IsKeyDown(Settings.GetKey("Activate")) || !KeyInput.IsKeyDown(Keys.LeftControl) && MouseInput.IsRightClicked)
 					game.SpellManager.Activate(CurrentSpell);
 
 				for (int i = 0; i < Math.Max(spellCount, 10); i++)

--- a/WarriorsSnuggery.Game/UI/Screens/Settings/KeySettingsScreen.cs
+++ b/WarriorsSnuggery.Game/UI/Screens/Settings/KeySettingsScreen.cs
@@ -22,19 +22,19 @@ namespace WarriorsSnuggery.UI.Screens
 			var tPause = new UIText(font, TextOffset.RIGHT) { Position = new CPos(-1024, -4096, 0) };
 			tPause.SetText("Pause/unpause");
 			Add(tPause);
-			pause = new KeyboardButton(Settings.KeyDictionary["Pause"], type) { Position = new CPos(1536, -4096, 0) };
+			pause = new KeyboardButton(Settings.GetKey("Pause"), type) { Position = new CPos(1536, -4096, 0) };
 			Add(pause);
 
 			var tLock = new UIText(font, TextOffset.RIGHT) { Position = new CPos(-1024, -3072, 0) };
 			tLock.SetText("Toggle camera lock");
 			Add(tLock);
-			@lock = new KeyboardButton(Settings.KeyDictionary["CameraLock"], type) { Position = new CPos(1536, -3072, 0) };
+			@lock = new KeyboardButton(Settings.GetKey("CameraLock"), type) { Position = new CPos(1536, -3072, 0) };
 			Add(@lock);
 
 			var tactivate = new UIText(font, TextOffset.RIGHT) { Position = new CPos(-1024, -2048, 0) };
 			tactivate.SetText("Activate spell/actor");
 			Add(tactivate);
-			activate = new KeyboardButton(Settings.KeyDictionary["Activate"], type) { Position = new CPos(1536, -2048, 0) };
+			activate = new KeyboardButton(Settings.GetKey("Activate"), type) { Position = new CPos(1536, -2048, 0) };
 			Add(activate);
 
 			var tMove = new UIText(font, TextOffset.RIGHT) { Position = new CPos(-3072, -1024, 0) };
@@ -48,17 +48,17 @@ namespace WarriorsSnuggery.UI.Screens
 				line++;
 				Add(text);
 			}
-			up = new KeyboardButton(Settings.KeyDictionary["MoveUp"], type) { Position = new CPos(1536, -1024, 0) };
+			up = new KeyboardButton(Settings.GetKey("MoveUp"), type) { Position = new CPos(1536, -1024, 0) };
 			Add(up);
-			down = new KeyboardButton(Settings.KeyDictionary["MoveDown"], type) { Position = new CPos(1536, -1024 + 640, 1) };
+			down = new KeyboardButton(Settings.GetKey("MoveDown"), type) { Position = new CPos(1536, -1024 + 640, 1) };
 			Add(down);
-			left = new KeyboardButton(Settings.KeyDictionary["MoveLeft"], type) { Position = new CPos(1536, -1024 + 1280, 1) };
+			left = new KeyboardButton(Settings.GetKey("MoveLeft"), type) { Position = new CPos(1536, -1024 + 1280, 1) };
 			Add(left);
-			right = new KeyboardButton(Settings.KeyDictionary["MoveRight"], type) { Position = new CPos(1536, -1024 + 1920, 0) };
+			right = new KeyboardButton(Settings.GetKey("MoveRight"), type) { Position = new CPos(1536, -1024 + 1920, 0) };
 			Add(right);
-			above = new KeyboardButton(Settings.KeyDictionary["MoveAbove"], type) { Position = new CPos(1536, -1024 + 2560, 1) };
+			above = new KeyboardButton(Settings.GetKey("MoveAbove"), type) { Position = new CPos(1536, -1024 + 2560, 1) };
 			Add(above);
-			below = new KeyboardButton(Settings.KeyDictionary["MoveBelow"], type) { Position = new CPos(1536, -1024 + 3200, 0) };
+			below = new KeyboardButton(Settings.GetKey("MoveBelow"), type) { Position = new CPos(1536, -1024 + 3200, 0) };
 			Add(below);
 
 			var tCam = new UIText(font, TextOffset.RIGHT) { Position = new CPos(-3072, 3072, 0) };
@@ -72,13 +72,13 @@ namespace WarriorsSnuggery.UI.Screens
 				line++;
 				Add(text);
 			}
-			camUp = new KeyboardButton(Settings.KeyDictionary["CameraUp"], type) { Position = new CPos(1536, 3072, 0) };
+			camUp = new KeyboardButton(Settings.GetKey("CameraUp"), type) { Position = new CPos(1536, 3072, 0) };
 			Add(camUp);
-			camDown = new KeyboardButton(Settings.KeyDictionary["CameraDown"], type) { Position = new CPos(1536, 3072 + 640, 1) };
+			camDown = new KeyboardButton(Settings.GetKey("CameraDown"), type) { Position = new CPos(1536, 3072 + 640, 1) };
 			Add(camDown);
-			camLeft = new KeyboardButton(Settings.KeyDictionary["CameraLeft"], type) { Position = new CPos(1536, 3072 + 1280, 1) };
+			camLeft = new KeyboardButton(Settings.GetKey("CameraLeft"), type) { Position = new CPos(1536, 3072 + 1280, 1) };
 			Add(camLeft);
-			camRight = new KeyboardButton(Settings.KeyDictionary["CameraRight"], type) { Position = new CPos(1536, 3072 + 1920, 1) };
+			camRight = new KeyboardButton(Settings.GetKey("CameraRight"), type) { Position = new CPos(1536, 3072 + 1920, 1) };
 			Add(camRight);
 		}
 

--- a/core/scripts/Tutorial1Script.cs
+++ b/core/scripts/Tutorial1Script.cs
@@ -39,7 +39,7 @@ namespace WarriorsSnuggery.Scripts.Core
 			{
 				$"Welcome to Warrior's Snuggery!",
 				$"First you'll learn how to {Color.Yellow}Move{Color.White}.",
-				$"You can move with the following keys: {Color.Yellow}{Settings.KeyDictionary["MoveUp"]}{Color.White},{Color.Yellow}{Settings.KeyDictionary["MoveLeft"]}{Color.White},{Color.Yellow}{Settings.KeyDictionary["MoveDown"]}{Color.White},{Color.Yellow}{Settings.KeyDictionary["MoveRight"]}{Color.White}.",
+				$"You can move with the following keys: {Color.Yellow}{Settings.GetKey("MoveUp")}{Color.White},{Color.Yellow}{Settings.GetKey("MoveLeft")}{Color.White},{Color.Yellow}{Settings.GetKey("MoveDown")}{Color.White},{Color.Yellow}{Settings.GetKey("MoveRight")}{Color.White}.",
 				$"Press {Color.Cyan}Continue {Color.White}to proceed."
 			}));
 		}


### PR DESCRIPTION
Replaces generic "key not found" exceptions with the custom exception from https://github.com/abc013/WarriorsSnuggery/blob/4c5551a155b7fd81ee04c9d056b4da3453622abc/WarriorsSnuggery.Game/Settings.cs#L108